### PR TITLE
Cover content on initial page load to fix the screen flash effect

### DIFF
--- a/components/shared/Loading.tsx
+++ b/components/shared/Loading.tsx
@@ -3,17 +3,37 @@ import styled from 'styled-components'
 import debounce from 'debounce'
 import BoxAnimator from 'src/BoxAnimator'
 
+const ANIMATION_PERIOD = 1400
+
 const Canvas = styled.canvas`
   display: block;
   margin: 0 auto;
 `
 
-export default function Loading() {
+interface LoadingProps {
+  width?: number
+  height?: number
+}
+
+// Default canvas size
+const defaultSize: Required<LoadingProps> = {
+  width: 264,
+  height: 400,
+}
+
+export default function Loading(props: LoadingProps) {
   const canvasElement = useRef<HTMLCanvasElement>(null)
 
-  const [width, setWidth] = useState(264)
-  const [height, setHeight] = useState(400)
+  const [width, setWidth] = useState(props.width || defaultSize.width)
+  const [height, setHeight] = useState(props.height || defaultSize.height)
 
+  // subscribe to props updates
+  useEffect(() => {
+    setWidth(props.width)
+    setHeight(props.height)
+  }, [props.width, props.height])
+
+  // start the animation when mounted
   useEffect(() => {
     const context = canvasElement.current.getContext('2d')
 
@@ -22,7 +42,7 @@ export default function Loading() {
     }
 
     // start the animation
-    const animator = new BoxAnimator(context, 1000)
+    const animator = new BoxAnimator(context, ANIMATION_PERIOD)
     setupAnimations(animator)
     animator.start()
 
@@ -95,11 +115,11 @@ export default function Loading() {
 function setupAnimations(animator: BoxAnimator) {
   // prettier-ignore
   animator.addBoxAt(1, 0.5, 0)
-    .animateTo(0, 0.5, 0).at(500)
-    .animateTo(0, 0.5, 1).at(1000);
+    .animateTo(0, 0.5, 0).at(ANIMATION_PERIOD / 2)
+    .animateTo(0, 0.5, 1).at(ANIMATION_PERIOD);
 
   // prettier-ignore
   animator.addBoxAt(0, 0.5, 1)
-    .animateTo(1, 0.5, 1).at(500)
-    .animateTo(1, 0.5, 0).at(1000);
+    .animateTo(1, 0.5, 1).at(ANIMATION_PERIOD / 2)
+    .animateTo(1, 0.5, 0).at(ANIMATION_PERIOD);
 }

--- a/components/shared/LoadingScreen.tsx
+++ b/components/shared/LoadingScreen.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components'
+
+const Screen = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  background: ${(props) => props.theme.colors.background};
+`
+
+/**
+ * This screen will cover the entire page and is used to
+ * stop the flashing effect when the page is not ready.
+ */
+export default function LoadingScreen() {
+  return <Screen aria-hidden="true" />
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
       "version": "7.16.4",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
       "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -81,7 +80,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
       "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@babel/generator": "^7.16.0",
@@ -111,7 +109,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
       "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.16.0"
       },
@@ -123,7 +120,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -132,7 +128,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -173,7 +168,6 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
       "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-validator-option": "^7.14.5",
@@ -191,7 +185,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -235,7 +228,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
       "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.0"
       },
@@ -258,7 +250,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
       "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-replace-supers": "^7.16.0",
@@ -277,7 +268,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
       "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.0"
       },
@@ -297,7 +287,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
       "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.16.0",
         "@babel/helper-optimise-call-expression": "^7.16.0",
@@ -312,7 +301,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
       "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.0"
       },
@@ -343,7 +331,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
       "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -352,7 +339,6 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
       "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.0",
         "@babel/traverse": "^7.16.3",
@@ -2958,7 +2944,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
       "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
-      "dev": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001280",
         "electron-to-chromium": "^1.3.896",
@@ -3332,7 +3317,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -4994,7 +4978,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -6675,7 +6658,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -7564,8 +7546,7 @@
     "node_modules/node-releases": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
-      "dev": true
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -7956,8 +7937,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -10092,14 +10072,12 @@
     "@babel/compat-data": {
       "version": "7.16.4",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
-      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
-      "dev": true
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q=="
     },
     "@babel/core": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
       "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/generator": "^7.16.0",
@@ -10122,7 +10100,6 @@
           "version": "7.16.0",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
           "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.16.0"
           }
@@ -10130,14 +10107,12 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -10170,7 +10145,6 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
       "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-validator-option": "^7.14.5",
@@ -10181,8 +10155,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -10216,7 +10189,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
       "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -10233,7 +10205,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
       "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-replace-supers": "^7.16.0",
@@ -10249,7 +10220,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
       "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -10263,7 +10233,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
       "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
-      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.16.0",
         "@babel/helper-optimise-call-expression": "^7.16.0",
@@ -10275,7 +10244,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
       "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -10296,14 +10264,12 @@
     "@babel/helper-validator-option": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
     },
     "@babel/helpers": {
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
       "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.16.0",
         "@babel/traverse": "^7.16.3",
@@ -10661,7 +10627,8 @@
     "@hcaptcha/react-hcaptcha": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-0.3.9.tgz",
-      "integrity": "sha512-yc3rRVQCz3w+rq9+Y1yi+hUlZscMDoXli0st8liefZ79gkFRa3vqd2zl+qGeRq+3HG7i+ydNNIXmnWhg8wJCSg=="
+      "integrity": "sha512-yc3rRVQCz3w+rq9+Y1yi+hUlZscMDoXli0st8liefZ79gkFRa3vqd2zl+qGeRq+3HG7i+ydNNIXmnWhg8wJCSg==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -11019,7 +10986,8 @@
     "@next/react-refresh-utils": {
       "version": "12.0.7",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.7.tgz",
-      "integrity": "sha512-Pglj1t+7RxH0txEqVcD8ZxrJgqLDmKvQDqxKq3ZPRWxMv7LTl7FVT2Pnb36QFeBwCvMVl67jxsADKsW0idz8sA=="
+      "integrity": "sha512-Pglj1t+7RxH0txEqVcD8ZxrJgqLDmKvQDqxKq3ZPRWxMv7LTl7FVT2Pnb36QFeBwCvMVl67jxsADKsW0idz8sA==",
+      "requires": {}
     },
     "@next/swc-android-arm64": {
       "version": "12.0.7",
@@ -11800,7 +11768,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -12276,7 +12245,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
       "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001280",
         "electron-to-chromium": "^1.3.896",
@@ -12570,7 +12538,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -13122,25 +13089,29 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-jsx": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
       "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-react": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-react/-/eslint-config-standard-react-11.0.1.tgz",
       "integrity": "sha512-4WlBynOqBZJRaX81CBcIGDHqUiqxvw4j/DbEIICz8QkMs3xEncoPgAoysiqCSsg71X92uhaBc8sgqB96smaMmg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-with-typescript": {
       "version": "21.0.1",
@@ -13319,7 +13290,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.27.1",
@@ -13374,13 +13346,15 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-standard": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
       "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -13789,8 +13763,7 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -14725,7 +14698,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -15017,7 +14991,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -15689,8 +15662,7 @@
     "node-releases": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
-      "dev": true
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -15978,8 +15950,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -16317,7 +16288,8 @@
     "react-collapse": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.1.tgz",
-      "integrity": "sha512-k6cd7csF1o9LBhQ4AGBIdxB60SUEUMQDAnL2z1YvYNr9KoKr+nDkhN6FK7uGaBd/rYrYfrMpzpmJEIeHRYogBw=="
+      "integrity": "sha512-k6cd7csF1o9LBhQ4AGBIdxB60SUEUMQDAnL2z1YvYNr9KoKr+nDkhN6FK7uGaBd/rYrYfrMpzpmJEIeHRYogBw==",
+      "requires": {}
     },
     "react-dom": {
       "version": "17.0.2",
@@ -16332,12 +16304,14 @@
     "react-hook-form": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.20.5.tgz",
-      "integrity": "sha512-xYeBmQW6oqxDYAYVWIoZYC7tRD6lJBJt9b8Rr1Mv/VhZ+ZUCy2IuXlm2YA9i0/zl0TKKxqBWQOxGEb3qyVIhMg=="
+      "integrity": "sha512-xYeBmQW6oqxDYAYVWIoZYC7tRD6lJBJt9b8Rr1Mv/VhZ+ZUCy2IuXlm2YA9i0/zl0TKKxqBWQOxGEb3qyVIhMg==",
+      "requires": {}
     },
     "react-icons": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ=="
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",
@@ -17012,7 +16986,8 @@
     "stylis-rule-sheet": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "requires": {}
     },
     "supports-color": {
       "version": "7.2.0",
@@ -17529,7 +17504,8 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,11 +5,14 @@ import PreviewBanner from 'components/shared/PreviewBanner'
 import { defaultTheme } from 'styles/themes'
 import GlobalStyles from 'styles/global'
 import { guardEnv } from 'src/utils'
+import useReady from 'src/hooks/useReady'
+import LoadingScreen from 'components/shared/LoadingScreen'
 
 export const theme = defaultTheme
 
 export default function App({ Component, pageProps }) {
   const router = useRouter()
+  const ready = useReady()
 
   const siteURL = guardEnv(
     'NEXT_PUBLIC_SITE_URL or VERCEL_URL',
@@ -42,6 +45,13 @@ export default function App({ Component, pageProps }) {
       <ThemeProvider theme={theme}>
         <PreviewBanner isPreview={pageProps.preview} />
         <Component {...pageProps} />
+
+        {/*
+          Show a blank cover if homepage is not ready 
+          so that there isn't a flashing effect but
+          text is still accessible to screen readers
+        */}
+        {!ready && router.pathname === '/' && <LoadingScreen />}
         <GlobalStyles />
       </ThemeProvider>
     </>

--- a/src/hooks/useReady.ts
+++ b/src/hooks/useReady.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+
+// Hook to check if the document is ready
+export default function useReady() {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    setReady(true)
+  }, [])
+
+  return ready
+}

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -4,7 +4,9 @@ import { theme } from 'pages/_app'
 
 const { mobile: mobileBreakpoint, tablet: tabletBreakpoint } = theme.breakpoints
 
-function useResponsive(customBreakpoint: number = mobileBreakpoint) {
+export default function useResponsive(
+  customBreakpoint: number = mobileBreakpoint
+) {
   const [isClient, setIsClient] = useState(false)
 
   const isMobile = useMediaQuery({
@@ -34,5 +36,3 @@ function useResponsive(customBreakpoint: number = mobileBreakpoint) {
     isCustom: isClient && customBreakpoint && isCustom,
   }
 }
-
-export default useResponsive

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,17 @@
 import { Ref, MutableRefObject } from 'react'
 
 // ensure that an environment variable is set
+class EnvironmentError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'EnvironmentError'
+  }
+}
+
 export function guardEnv(name: string, value?: string) {
   const valueIsUndefined = typeof value === 'undefined'
   if (valueIsUndefined && typeof process.env[name] === 'undefined') {
-    throw new Error(`${name} environment variable must be set.`)
+    throw new EnvironmentError(`${name} environment variable must be set.`)
   }
 
   return valueIsUndefined ? process.env[name] : value


### PR DESCRIPTION
This PR fixes the screen flash issue wherein content appears momentarily and is immediately re-animated. The cover should be hidden to screen readers and therefore should not affect scrapers such as googlebot.