### PR TITLE
Always fade in top row

### DIFF
--- a/components/homepage/Showcase.tsx
+++ b/components/homepage/Showcase.tsx
@@ -163,6 +163,7 @@ function ShowcaseDesktopItem({
         distance="50%"
         wait={fadeDelay}
         onReveal={onInfoRevealed}
+        when={isFirstRow ? true : undefined}
       >
         <div>
           <ShowcaseTitle showcaseData={item} />


### PR DESCRIPTION
This indicates to the user that there is more content worth scrolling to see. It fixes a bug where the first showcase item wouldn't show on certain desktop displays.